### PR TITLE
Fix innerHTML errors by updating class on main element

### DIFF
--- a/slader-limit-bypass/js/quizlet_bypass.js
+++ b/slader-limit-bypass/js/quizlet_bypass.js
@@ -19,7 +19,7 @@ function renderBypass()
 function processData(data){
     // Clear the "hidden explanation" out and replace it with a blank explanation area.
     // The innermost item is ".s1i7awl8"
-    document.querySelector('main .mwhvwas').innerHTML = '<div class="c18oith1 sladerBypass"><div class="s1oluvjw"><h4 class="h1cwp1lk">Explanation</h4><div class="as7m9cv snqbbas"><div data-testid="ExplanationsSolution" class="e1sw891e"><div class="s1i7awl8"></div></div></div></div></div>';
+    document.querySelector('main .mv7e89c').innerHTML = '<div class="c18oith1 sladerBypass"><div class="s1oluvjw"><h4 class="h1cwp1lk">Explanation</h4><div class="as7m9cv snqbbas"><div data-testid="ExplanationsSolution" class="e1sw891e"><div class="s1i7awl8"></div></div></div></div></div>';
     var expArea = document.querySelector('.sladerBypass .s1i7awl8')
 
     // Render new stuff

--- a/slader-limit-bypass/js/quizlet_bypass.js
+++ b/slader-limit-bypass/js/quizlet_bypass.js
@@ -56,7 +56,7 @@ function processData(data){
             // Create card element
             var div = document.createElement('div');
             // Insert boilerplate card data
-            div.innerHTML = '<div class="r8gl7vf" data-testid="ExplanationsSolutionStep" style="padding-top: 0.8rem;"><div class="AssemblyCard AssemblyMediumCard"><div class="ExplanationsSolutionCard c5ngj6s"><div class="h1ejaztj"><h4 class="s39tzu2"></h4><span class="sb9ch1t"></span></div><div class="s1wwu7g8"><div class="s1x7f4sz"><div class=""><div class="s1xkd811"><div class="mi4ni5d sladerBypassKatex" style="white-space: pre-wrap;"></div></div></div></div></div></div></div></div>';
+            div.innerHTML = '<div class="r8gl7vf" data-testid="ExplanationsSolutionStep" style="padding-top: 0.8rem;"><div class="AssemblyCard AssemblyMediumCard"><div class="ExplanationsSolutionCard c5ngj6s"><div class="h1ejaztj"><h4 class="s39tzu2"></h4><span class="sb9ch1t"></span></div><div class="s1wwu7g8"><div class="s1x7f4sz"><div class=""><div class="s1xkd811" style="line-height: 2"><div class="mi4ni5d sladerBypassKatex" style="white-space: pre-wrap;"></div></div></div></div></div></div></div></div>';
             // Step X: .s39tzu2
             div.querySelector('.s39tzu2').textContent = (numSteps === stepNum) ? "Result" : "Step " + stepNum;
             // x of x: .sb9ch1t

--- a/slader-limit-bypass/js/quizlet_bypass.js
+++ b/slader-limit-bypass/js/quizlet_bypass.js
@@ -56,7 +56,7 @@ function processData(data){
             // Create card element
             var div = document.createElement('div');
             // Insert boilerplate card data
-            div.innerHTML = '<div class="r8gl7vf" data-testid="ExplanationsSolutionStep" style="padding-top: 0.8rem;"><div class="AssemblyCard AssemblyMediumCard"><div class="ExplanationsSolutionCard c5ngj6s"><div class="h1ejaztj"><h4 class="s39tzu2"></h4><span class="sb9ch1t"></span></div><div class="s1wwu7g8"><div class="s1x7f4sz"><div class=""><div class="s1xkd811" style="line-height: 2"><div class="mi4ni5d sladerBypassKatex" style="white-space: pre-wrap;"></div></div></div></div></div></div></div></div>';
+            div.innerHTML = '<div class="r8gl7vf" data-testid="ExplanationsSolutionStep" style="padding-top: 0.8rem;"><div class="AssemblyCard AssemblyMediumCard"><div class="ExplanationsSolutionCard c5ngj6s"><div class="h1ejaztj"><h4 class="s39tzu2"></h4><span class="sb9ch1t"></span></div><div class="s1wwu7g8"><div class="s1x7f4sz"><div class=""><div class="s1xkd811" style="line-height: auto"><div class="mi4ni5d sladerBypassKatex" style="white-space: pre-wrap;"></div></div></div></div></div></div></div></div>';
             // Step X: .s39tzu2
             div.querySelector('.s39tzu2').textContent = (numSteps === stepNum) ? "Result" : "Step " + stepNum;
             // x of x: .sb9ch1t


### PR DESCRIPTION
Just stumbled across the code in a broken state today -- seems like the class name on the main element has changed. I'm not sure if Slader/Quizlet changed this on purpose in response to this bypass, or if they just changed their website around internally.

But this change should fix any innerHTML errors and get the QLoad and everything working again, although for some reason my solution container has all lines of the solution coalesced onto one line like this:
![image](https://user-images.githubusercontent.com/37674516/127560508-1b90debd-e99a-402f-856e-e6aa1779ad1e.png)

**Update**: Seems like the site is adding a `line-height: 0` to the div with class `s1xkd811` -- I added an explicit `line-height: auto` to the bypass' injected HTML to nullify the website's inherited styles. Some lines look a little tight sometimes like this:
![image](https://user-images.githubusercontent.com/37674516/127562088-8038d85a-2e19-4cd6-9ed0-1a2ea17e8eac.png)

[Update again]: Ok I read through some of the currently posted issues, and yeah only the first part of the question is fetched, and the rest is fetched after the reveal all steps button)

Looks like incognito and new accounts is the way to go for now
